### PR TITLE
Configure reset.css

### DIFF
--- a/_app/css/reset.css
+++ b/_app/css/reset.css
@@ -1,5 +1,32 @@
-* {
+*,
+*::before,
+*::after {
 	box-sizing: border-box;
+}
+
+*{ 
 	margin: 0;
 	padding: 0;
+}
+
+img,
+video,
+canvas {
+	display: block;
+	width: 100%;
+}
+
+button,
+select {
+	cursor: pointer;
+}
+
+button,
+input,
+select {
+	font: inherit;
+	color: inherit;
+	background: transparent;
+	border: 0;
+	outline: 0; /* Remove default for custom outline */
 }


### PR DESCRIPTION
Set up the reset.css file. I made all elements have the same box-sizing, removed margins and padding, set images and videos to full width, made buttons and selects have a pointer cursor, and took away the default outlines from buttons, inputs, and selects.