### PR TITLE
Set up font variables

### DIFF
--- a/_app/css/fonts.css
+++ b/_app/css/fonts.css
@@ -1,0 +1,21 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital@1&family=Oswald&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Oswald&family=Saira+Condensed:wght@500&display=swap');
+
+:root {
+    --font-main: 'Montserrat', sans-serif;
+    --font-secondary: 'Cormorant Garamond', serif;
+    --font-tertiary: 'Oswald', sans-serif;
+}
+
+body {
+    font-family: var(--font-main);
+}
+
+h1, h2, h3 {
+    font-family: var(--font-secondary);
+}
+
+.nav__link {
+    font-family: var(--font-tertiary);
+}


### PR DESCRIPTION
Set up the font variables in the CSS. I imported the Montserrat, Cormorant Garamond, and Oswald fonts from Google Fonts and defined them as primary, secondary, and tertiary fonts. I then applied these fonts to different elements: Montserrat to the body, Cormorant Garamond to the headings, and Oswald to the navigation links.