### PR TITLE
Create imageStyle schema and populate with data

### DIFF
--- a/_studio/schemas/documents/imageStyle.js
+++ b/_studio/schemas/documents/imageStyle.js
@@ -1,0 +1,37 @@
+export default {
+	name: 'imageStyle',
+	title: 'Image Style',
+	type: 'document',
+	fields: [
+	{
+		 name: 'name',
+		 title: 'Name',
+		 type: 'string',
+		 description: 'Name of the image style',
+         validation: rule => rule.required()
+	},
+	{
+		 name: 'slug',
+		 title: 'Slug',
+		 type: 'slug',
+		 options: {
+			source: 'name',
+			maxLength: 200,
+		 },
+		 description: 'Slug for the image style',
+	},
+	{
+		 name: 'description',
+		 title: 'Description',
+		 type: 'text',
+		 description: 'Description of the image style',
+	},
+    {
+        name: 'transformedImages',
+        title: 'Transformed Image',
+        type: 'reference',
+        to: [{ type: 'transformedImages' }],
+        description: 'Transformed image associated with the image style',
+     },
+  ],
+};

--- a/_studio/schemas/documents/transformedImages.js
+++ b/_studio/schemas/documents/transformedImages.js
@@ -1,6 +1,6 @@
 export default {
-	name: 'transformationImages',
-	title: 'Transformation Images',
+	name: 'transformedImages',
+	title: 'Transformed Images',
 	type: 'document',
 	fields: [
 	{
@@ -30,13 +30,13 @@ export default {
 		description: 'Image of the transformation',
 		validation: rule=> rule.required()
 	},
-	{
-		name: 'athlete',
-		title: 'Athlete',
-		type: 'reference',
-		to: [{ type: 'athlete' }],
-		description: 'Athlete associated with the transformation image',
-	},
+	// {
+	// 	name: 'athlete',
+	// 	title: 'Athlete',
+	// 	type: 'reference',
+	// 	to: [{ type: 'athlete' }],
+	// 	description: 'Athlete associated with the transformation image',
+	// },
 	{
 		name: 'sportCategory',
 		title: 'Sport Category',

--- a/_studio/schemas/schemas.js
+++ b/_studio/schemas/schemas.js
@@ -1,4 +1,5 @@
+import imageStyle from './documents/imageStyle.js';
 import sportCategory from './documents/sportCategory.js'
 import transformedImages from './documents/transformedImages.js';
 
-export default [sportCategory, transformedImages];
+export default [sportCategory, transformedImages, imageStyle];


### PR DESCRIPTION
* Created the "imageStyle" schema and referenced the "transformedImages" schema.
* Referenced "transformedImages" in the "imageStyle" schema.
* Populated the "imageStyle" schema with art styles and descriptions in Sanity Studio.
* Linked the "imageStyle" schema to "schemas.js".