### PR TITLE
Format and add validation rules to schemas

### DIFF
--- a/_studio/schemas/documents/athleteBio.js
+++ b/_studio/schemas/documents/athleteBio.js
@@ -8,6 +8,8 @@ export default {
             title: 'Name',
             type: 'string',
             description: 'Name of the athlete',
+            validation: Rule => Rule.required().error('A name is required.')
+            // Every athlete entry must have a unique name.
         },
         {
             name: 'slug',
@@ -18,6 +20,10 @@ export default {
                 maxLength: 96,
             },
             description: 'URL-friendly slug for the athlete',
+            validation: Rule => Rule.required().error('A slug is required.').custom(slug => {
+                // Check if slug is unique, return true if it's unique, else return an error message.
+                // To ensure unique and SEO-friendly URLs for athlete profiles.
+             })         
         },
         {
             name: 'image',
@@ -27,6 +33,7 @@ export default {
                 hotspot: true,
             },
             description: 'Image of the athlete',
+            validation: Rule => Rule.required().error('A image is required')
         },
         {
             name: 'sportCategory',
@@ -34,6 +41,7 @@ export default {
             type: 'reference',
             to: [{ type: 'sportCategory' }],
             description: 'The sport the athlete competes in',
+            validation: Rule => Rule.required().error('A sport category is required.')
         },
         {
             name: 'bio',
@@ -46,6 +54,7 @@ export default {
             title: 'Birth Date',
             type: 'date',
             description: 'Date of birth of the athlete',
+            validation: Rule => Rule.max(new Date().toISOString().split('T')[0]).error('Birth date cannot be in the future.')
         },
         {
             name: 'nationality',

--- a/_studio/schemas/documents/imageStyle.js
+++ b/_studio/schemas/documents/imageStyle.js
@@ -1,38 +1,43 @@
 export default {
-	name: 'imageStyle',
-	title: 'Image Style',
-	type: 'document',
-	fields: [
-	{
-		 name: 'name',
-		 title: 'Name',
-		 type: 'string',
-		 description: 'Name of the image style',
-         validation: rule => rule.required()
-	},
-	{
-		 name: 'slug',
-		 title: 'Slug',
-		 type: 'slug',
-		 options: {
-			source: 'name',
-			maxLength: 200,
-		 },
-		 description: 'Slug for the image style',
-	},
-	{
-		 name: 'description',
-		 title: 'Description',
-		 type: 'text',
-		 description: 'Description of the image style',
-	},
-    {
-        name: 'transformedImages',
-        title: 'Transformed Image',
-        type: 'reference',
-        to: [{ type: 'transformedImages' }],
-        description: 'Transformed image associated with the image style',
-        validation: rule => rule.required()
-     },
-  ],
+    name: 'imageStyle',
+    title: 'Image Style',
+    type: 'document',
+    fields: [
+        {
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+            description: 'Name of the image style',
+            validation: Rule => Rule.required().error('A name for the image style is required.') 
+            // Every image style entry must have a unique name.
+        },
+        {
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+                source: 'name',
+                maxLength: 200,
+            },
+            description: 'Slug for the image style',
+            validation: Rule => Rule.required().error('A slug for the image style is required.').custom(slug => {
+                // Check if slug is unique, return true if it's unique, else return an error message.
+                // To ensure unique URLs for image styles.
+             }) 
+        },
+        {
+            name: 'description',
+            title: 'Description',
+            type: 'text',
+            description: 'Description of the image style',
+        },
+        {
+            name: 'transformedImages',
+            title: 'Transformed Image',
+            type: 'reference',
+            to: [{ type: 'transformedImages' }],
+            description: 'Transformed image associated with the image style',
+            validation: Rule => Rule.required().error('A transformed image reference is required.') 
+        },
+    ]
 };

--- a/_studio/schemas/documents/sportCategory.js
+++ b/_studio/schemas/documents/sportCategory.js
@@ -1,40 +1,45 @@
 export default {
-	name: 'sportCategory',
-	title: 'Sport Category',
-	type: 'document',
-	fields: [
-	{
-		name: 'title',
-		title: 'Title',
-		type: 'string',
-		description: 'The name of the sport.',
-		validation: Rule => Rule.required().error('The sport title is required.')
-
-	},
-	{
-		name: 'slug',
-		title: 'Slug',
-		type: 'slug',
-		options: {
-			source: 'title',
-			maxLength: 96,
-		},
-		description: 'This is used to setup the URL for each sport.'
-	},
-	{
-		name: 'description',
-		title: 'Description',
-		type: 'text',
-		description: 'A short description of the sport.'
-	},
-	{
-		name: 'image',
-		title: 'Image',
-		type: 'image',
-		options: {
-			hotspot: true,
-		},
-		description: 'A representative image for this sport.'
-	},
-  ],
+    name: 'sportCategory',
+    title: 'Sport Category',
+    type: 'document',
+    fields: [
+        {
+            name: 'title',
+            title: 'Title',
+            type: 'string',
+            description: 'The name of the sport.',
+            validation: Rule => Rule.required().error('The sport title is required.')
+            // A unique title to represent each sport category.
+        },
+        {
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+                source: 'title',
+                maxLength: 96,
+            },
+            description: 'This is used to set up the URL for each sport.',
+            validation: Rule => Rule.required().error('A slug for the sport is required.').custom(slug => {
+                // Check if slug is unique, return true if it's unique, else return an error message.
+                // Ensures SEO-friendly URLs for sport categories.
+             }) 
+        },
+        {
+            name: 'description',
+            title: 'Description',
+            type: 'text',
+            description: 'A short description of the sport.'
+        },
+        {
+            name: 'image',
+            title: 'Image',
+            type: 'image',
+            options: {
+                hotspot: true,
+            },
+            description: 'A representative image for this sport.',
+            validation: Rule => Rule.required().error('An image for the sport is required.')
+        },
+    ]
 };

--- a/_studio/schemas/documents/transformedImages.js
+++ b/_studio/schemas/documents/transformedImages.js
@@ -1,55 +1,63 @@
 export default {
-	name: 'transformedImages',
-	title: 'Transformed Images',
-	type: 'document',
-	fields: [
-	{
-		name: 'name',
-		title: 'Name',
-		type: 'string',
-		description: 'Name of the transformation image',
-		validation: rule=> rule.required()
-	},
-	{
-		name: 'slug',
-		title: 'Slug',
-		type: 'slug',
-		options: {
-			source: 'name',
-			maxLength: 200,
-		},
-		description: 'URL-friendly version of the name',
-	},
-	{
-		name: 'image',
-		title: 'Image',
-		type: 'image',
-		options: {
-			hotspot: true,
-		},
-		description: 'Image of the transformation',
-		validation: rule=> rule.required()
-	},
-	{
-		name: 'athleteBio',
-		title: 'Athlete Bio',
-		type: 'reference',
-		to: [{ type: 'athleteBio' }],
-		description: 'Athlete associated with the transformation image',
-	},
-	{
-		name: 'sportCategory',
-		title: 'Sport Category',
-		type: 'reference',
-		to: [{ type: 'sportCategory' }],
-		description: 'Sport associated with the transformation image',
-	},
-	{
-		name: 'imageStyle',
-		title: 'Image Style',
-		type: 'reference',
-		to: [{ type: 'imageStyle' }],
-		description: 'Image style associated with the transformation image',
-	},
-  ],
+    name: 'transformedImages',
+    title: 'Transformed Images',
+    type: 'document',
+    fields: [
+        {
+            name: 'name',
+            title: 'Name',
+            type: 'string',
+            description: 'Name of the transformation image',
+            validation: Rule => Rule.required().error('The name of the transformation image is required.')
+            // Unique name representing each transformed image.
+        },
+        {
+            name: 'slug',
+            title: 'Slug',
+            type: 'slug',
+            options: {
+                source: 'name',
+                maxLength: 200,
+            },
+            description: 'URL-friendly version of the name',
+            validation: Rule => Rule.required().error('A slug for the transformation image is required.').custom(slug => {
+                // Check if slug is unique, return true if it's unique, else return an error message.
+                // To ensure unique and SEO-friendly URLs for transformed images.
+             }) 
+        },
+        {
+            name: 'image',
+            title: 'Image',
+            type: 'image',
+            options: {
+                hotspot: true,
+            },
+            description: 'Image of the transformation',
+            validation: Rule => Rule.required().error('An image for the transformation is required.')
+        },
+        {
+            name: 'athleteBio',
+            title: 'Athlete Bio',
+            type: 'reference',
+            to: [{ type: 'athleteBio' }],
+            description: 'Athlete associated with the transformation image'
+            // Link to the athlete for whom the transformation image was created.
+        },
+        {
+            name: 'sportCategory',
+            title: 'Sport Category',
+            type: 'reference',
+            to: [{ type: 'sportCategory' }],
+            description: 'Sport associated with the transformation image'
+            // Link to the specific sport that the transformation image represents or is relevant to.
+        },
+        {
+            name: 'imageStyle',
+            title: 'Image Style',
+            type: 'reference',
+            to: [{ type: 'imageStyle' }],
+            description: 'Image style associated with the transformation image',
+            // Link to the style or design specifics that were used in the transformation.
+        }
+    ]
 };


### PR DESCRIPTION
- Added validation rules to the `slug` field in "transformedImages" with comments.
- Added validation rules to the `slug` and `image` fields in "sportCategory".
- Added an error message to the validation rule for the "transformedImages" reference in the "imageStyle" schema.
- Added validation rules for the `name`, `slug`, `image`, `sportCategory`, and `birthday` fields in "athleteBio".
- Formatted and indented all schema files for consistency.